### PR TITLE
Hook dispatch refactor

### DIFF
--- a/examples/demo_actsteer.py
+++ b/examples/demo_actsteer.py
@@ -11,7 +11,7 @@ from vllm import SamplingParams
 
 if __name__ == "__main__":
 
-    cache_dir = "/dccstor/pyrite/irene/"
+    cache_dir = "./cache/"
     model = 'microsoft/Phi-3-mini-4k-instruct'
     
     dtype_map = {

--- a/examples/demo_attntracker.py
+++ b/examples/demo_attntracker.py
@@ -40,7 +40,7 @@ def apply_chat_template_and_get_ranges(tokenizer, model_name: str, instruction: 
 
 if __name__ == "__main__":
 
-    cache_dir = "/dccstor/pyrite/irene/"
+    cache_dir = "./cache/"
     model = 'ibm-granite/granite-3.1-8b-instruct'  # 'Qwen/Qwen2-1.5B-Instruct' # 'mistralai/Mistral-7B-Instruct-v0.3' # 
     
     dtype_map = {

--- a/examples/demo_corer.py
+++ b/examples/demo_corer.py
@@ -62,7 +62,7 @@ def apply_chat_template_and_get_ranges(tokenizer, model_name: str, query: str, d
 
 if __name__ == "__main__":
 
-    cache_dir = "/dccstor/pyrite/irene/"
+    cache_dir = "./cache/"
     model = 'mistralai/Mistral-7B-Instruct-v0.3' # 'ibm-granite/granite-3.1-8b-instruct'  # 'Qwen/Qwen2-1.5B-Instruct' #
     
     dtype_map = {

--- a/vllm_hook_plugins/vllm_hook_plugins/__init__.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/__init__.py
@@ -9,8 +9,8 @@ from vllm_hook_plugins.analyzers.core_reranker_analyzer import CorerAnalyzer
 def register_plugins():
 
     # Register workers
-    PluginRegistry.register_worker("probe_hook_qk", ProbeHookQKWorker)
-    PluginRegistry.register_worker("steer_hook_act", SteerHookActWorker)
+    PluginRegistry.register_worker("probe_hook_qk",  ProbeHookQKWorker,  hooks_on=(True,  False))
+    PluginRegistry.register_worker("steer_hook_act", SteerHookActWorker, hooks_on=(False, True))
     
     # Register analyzers
     PluginRegistry.register_analyzer("attn_tracker", AttntrackerAnalyzer)

--- a/vllm_hook_plugins/vllm_hook_plugins/hook_llm.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/hook_llm.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict, List
 os.environ.setdefault("TORCHDYNAMO_DISABLE", "1")
 
 from vllm import LLM, SamplingParams
+from vllm_hook_plugins.registry import PluginRegistry
 
 class HookLLM:
     def __init__(
@@ -48,7 +49,6 @@ class HookLLM:
         worker = None
         if worker_name:
             import vllm.plugins
-            from vllm_hook_plugins import PluginRegistry
             vllm.plugins.load_general_plugins()
             
             worker = PluginRegistry.get_worker(worker_name).path
@@ -109,50 +109,59 @@ class HookLLM:
         if not isinstance(prompts, list):
             prompts = [prompts]
 
-        if hook:
-            if "probe" in self.worker_name:
-                return self.generate_with_encode_hook(prompts, sampling_params, cleanup, **kwargs)
-            elif "steer" in self.worker_name:
-                return self.generate_with_decode_hook(prompts, sampling_params, cleanup, **kwargs)
-
-        else:
+        if not hook or not self.worker_name:
             if sampling_params is None:
                 sampling_params = SamplingParams(**kwargs)
             return self.llm.generate(prompts, sampling_params)
-    
+        
+        worker_entry = PluginRegistry.get_worker(self.worker_name)
+        hooks_on_prefill, hooks_on_generate = worker_entry.hooks_on if worker_entry else (False, False)
+
+        return self._generate_with_hooks(
+            prompts, sampling_params, cleanup,
+            hooks_on_prefill=hooks_on_prefill,
+            hooks_on_generate=hooks_on_generate,
+            **kwargs
+        )
+
+    def _generate_with_hooks(self, prompts, sampling_params, cleanup,
+                              hooks_on_prefill: bool, hooks_on_generate: bool, **kwargs):
+        if sampling_params is None:
+            sampling_params = SamplingParams(**kwargs)
+
+        if hooks_on_prefill and hooks_on_generate:
+            # Single-pass: hooks active throughout
+            self._setup_hooks(cleanup)
+            try:
+                return self.llm.generate(prompts, sampling_params)
+            finally:
+                self._cleanup_hooks()
+        else:
+            # Two-pass: prefill (max_tokens=1) then full generation
+            prefill_params = SamplingParams(temperature=0.1, max_tokens=1)
+
+            if hooks_on_prefill:
+                self._setup_hooks(cleanup)
+            self.llm.generate(prompts, prefill_params)
+            if hooks_on_prefill:
+                self._cleanup_hooks()
+
+            if hooks_on_generate:
+                self._setup_hooks(cleanup)
+            output = self.llm.generate(prompts, sampling_params)
+            if hooks_on_generate:
+                self._cleanup_hooks()
+
+            return output
+
+    ####### depreciated ####### 
     def generate_with_encode_hook(self, prompts, sampling_params, cleanup, **kwargs):
-
-        self._setup_hooks(cleanup)
-        
-        # prefill with hooks
-        prefill_params = SamplingParams(temperature=0.1, max_tokens=1)
-        self.llm.generate(prompts, prefill_params)
-        
-        self._cleanup_hooks()
-        output = None
-        # generation without hooks
-        if sampling_params is None:
-            sampling_params = SamplingParams(**kwargs)
-        output = self.llm.generate(prompts, sampling_params)
-        
-        return output
-    
+        return self._generate_with_hooks(prompts, sampling_params, cleanup,
+                                          hooks_on_prefill=True, hooks_on_generate=False, **kwargs)
+    ####### depreciated ####### 
     def generate_with_decode_hook(self, prompts, sampling_params, cleanup, **kwargs):
-        
-        # prefill without hooks
-        prefill_params = SamplingParams(temperature=0.1, max_tokens=1)
-        self.llm.generate(prompts, prefill_params)
-        
-        self._setup_hooks(cleanup)
-        
-        # generation with hooks
-        if sampling_params is None:
-            sampling_params = SamplingParams(**kwargs)
-        output = self.llm.generate(prompts, sampling_params)
-    
-        self._cleanup_hooks()
-
-        return output
+        return self._generate_with_hooks(prompts, sampling_params, cleanup,
+                                          hooks_on_prefill=False, hooks_on_generate=True, **kwargs)
     
     def analyze(
         self,

--- a/vllm_hook_plugins/vllm_hook_plugins/registry.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/registry.py
@@ -1,9 +1,10 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 class Worker:
-    def __init__(self, worker_class):
+    def __init__(self, worker_class, hooks_on: Tuple[bool, bool] = (False, False)):
         # self.cls = worker_class
         self.path = f"{worker_class.__module__}.{worker_class.__name__}"
+        self.hooks_on = hooks_on  # (hooks_on_prefill, hooks_on_generate)
 
 class Analyzer:
     def __init__(self, analyzer_class):
@@ -17,8 +18,8 @@ class PluginRegistry:
     
     ## workers
     @classmethod
-    def register_worker(cls, name: str, worker_class):
-        cls._workers[name] = Worker(worker_class)
+    def register_worker(cls, name: str, worker_class, hooks_on: Tuple[bool, bool] = (False, False)):
+        cls._workers[name] = Worker(worker_class, hooks_on)
     
     @classmethod
     def get_worker(cls, name: str) -> Optional[Worker]:


### PR DESCRIPTION
#### Summary
  - HookLLM.generate() previously dispatched to different execution strategies using string matching on worker names (if "probe" in self.worker_name)                       
  - Each worker is now registered with an explicit hooks_on=(prefill: bool, generate: bool) tuple in PluginRegistry                                          
  - generate() queries the registry for these flags and delegates to a unified _generate_with_hooks() method                                                                        

#### Motivation                                                                                                                                                                        
The string-based dispatch forced subclasses to override generate() just to get different hook timing behavior. The new design makes each worker self-describing, and lays the groundwork for multi-hook support (union the flags across workers). 

#### Backward compatibility                                                                                                                                                            
  - generate_with_encode_hook() and generate_with_decode_hook() kept as deprecated shims