### PR TITLE
fix: skip hidden-state hook work during CUDA graph capture

### DIFF
--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
@@ -76,6 +76,8 @@ class ProbeHiddenStatesWorker(V1Worker):
             # Warmup or non-attention passes: nothing to do
             if metadata is None:
                 return
+            if torch.cuda.is_current_stream_capturing():
+                return None
 
             # The HS worker hooks on "model.layers.<i>",
             # so we look up the corresponding attention key.


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR does and why -->
Skip hidden-state hook execution during CUDA graph capture.

## Type of contribution
- [ ] New worker
- [ ] New analyzer
- [x] Bug fix
- [ ] Other (describe below)

## Files modified
<!-- List the files changed. Note: hook_llm.py should not be modified. -->
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
- [x] I have NOT modified `hook_llm.py`

## Plugin architecture checklist
- [ ] New workers/analyzers are registered via `PluginRegistry` in `__init__.py`
- [ ] New workers extend `V1Worker` (not `HookLLM`)
- [ ] `hooks_on=(prefill, generate)` flag is set correctly for any new worker registration
- [ ] Examples or notebooks are included for new features

## Testing
<!-- Describe how you tested this. Which demo/example did you run? -->
- eager mode still works
- non-eager mode no longer fails during engine initialization

## Related issue
<!-- Link any related issue: Closes #123 -->
Fixes #6 