### PR TITLE
fix hidden state extraction: add fused residual to match native Eagle

### DIFF
--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
@@ -97,8 +97,11 @@ class ProbeHiddenStatesWorker(V1Worker):
                 [torch.tensor([0]).to(last_indices.device), last_indices]
             )
 
-            # output is a tuple (hidden_states, ...) or just a tensor
-            if isinstance(output, tuple):
+            # vLLM uses a fused residual pattern: transformer blocks return
+            # (hidden_states, residual) where the residual has not yet been added. 
+            if isinstance(output, tuple) and len(output) == 2 and isinstance(output[1], torch.Tensor):
+                hidden = output[0] + output[1]
+            elif isinstance(output, tuple):
                 hidden = output[0]
             else:
                 hidden = output


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR does and why -->

## Type of contribution
- [ ] New worker
- [ ] New analyzer
- [x] Bug fix
- [ ] Other (describe below)

## Files modified
<!-- List the files changed. Note: hook_llm.py should not be modified. -->
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
- [x] I have NOT modified `hook_llm.py`

## Plugin architecture checklist
- [ ] New workers/analyzers are registered via `PluginRegistry` in `__init__.py`
- [ ] New workers extend `V1Worker` (not `HookLLM`)
- [ ] `hooks_on=(prefill, generate)` flag is set correctly for any new worker registration
- [ ] Examples or notebooks are included for new features

## Testing
<!-- Describe how you tested this. Which demo/example did you run? -->

## Related issue
<!-- Link any related issue: Closes #123 -->
vLLM uses a fused residual pattern: transformer blocks return (hidden_states, residual) where the residual has not yet been added. 

