### PR TITLE
fix index hidden states with query_start_loc to handle prefix caching

### DIFF
--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
@@ -114,21 +114,21 @@ class ProbeHiddenStatesWorker(V1Worker):
 
             # The HS worker hooks on "model.layers.<i>",
             # so we look up the corresponding attention key.
-            seq_lens = getattr(metadata, "seq_lens", None)
-            if seq_lens is None and isinstance(metadata, dict):
+            # query_start_loc is the cumulative sum of per-request *query* token
+            # counts (shape [bs+1]).  Unlike cumsum(seq_lens), it excludes
+            # prefix-cached tokens and is always within hidden.shape[0].
+            query_start_loc = getattr(metadata, "query_start_loc", None)
+            if query_start_loc is None and isinstance(metadata, dict):
                 attn_key = f"{module_name}.self_attn.attn"
                 entry = metadata.get(attn_key)
                 if entry is not None:
-                    seq_lens = entry.seq_lens
+                    query_start_loc = getattr(entry, "query_start_loc", None)
 
-            if seq_lens is None:
+            if query_start_loc is None:
                 return
 
-            last_indices = torch.cumsum(seq_lens, dim=0)
-            bs = len(last_indices)
-            last_indices = torch.cat(
-                [torch.tensor([0]).to(last_indices.device), last_indices]
-            )
+            bs = len(query_start_loc) - 1
+            last_indices = query_start_loc
 
             # vLLM uses a fused residual pattern: transformer blocks return
             # (hidden_states, residual) where the residual has not yet been added. 


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR does and why -->
fix: use query_start_loc instead of cumsum(seq_lens) in hs_hook

With prefix caching enabled, seq_lens reflects full sequence lengths (including cached prefix tokens), but hidden.shape[0] equals only the query tokens actually computed this pass. Taking cumsum(seq_lens) as indices into hidden overflows when a cached prefix makes the full length exceed the number of computed tokens.

query_start_loc is the cumulative sum of per-request query token counts (shape [bs+1]) and is always within hidden.shape[0], so it is the better array to use for both last_token and all_tokens indexing.

## Type of contribution
- [ ] New worker
- [ ] New analyzer
- [x] Bug fix
- [ ] Other (describe below)

## Files modified
<!-- List the files changed. Note: hook_llm.py should not be modified. -->
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
- [x] I have NOT modified `hook_llm.py`

## Plugin architecture checklist
- [ ] New workers/analyzers are registered via `PluginRegistry` in `__init__.py`
- [ ] New workers extend `V1Worker` (not `HookLLM`)
- [ ] `hooks_on=(prefill, generate)` flag is set correctly for any new worker registration
- [ ] Examples or notebooks are included for new features

## Testing
<!-- Describe how you tested this. Which demo/example did you run? -->
Increase the length of the test cases
```
test_cases = [
    lorem.words(1000)
    for _ in range(100)
]
```
in `vLLM-Hook/examples/demo_hiddenstate.py`

## Related issue
<!-- Link any related issue: Closes #123 -->
fixes #5 