### PR TITLE
refactor ProbeHookQKWorker to match ProbeHiddenStatesWorker patterns 

### DIFF
--- a/examples/demo_attntracker.py
+++ b/examples/demo_attntracker.py
@@ -6,6 +6,8 @@ import time
 mp.set_start_method("spawn", force=True)
 os.environ["VLLM_USE_V1"] = "1"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+os.environ.setdefault("VLLM_HOOK_USE_SAFETENSORS", "1")
+os.environ.setdefault("VLLM_HOOK_ASYNC_SAVE", "1")
 
 from vllm_hook_plugins import HookLLM
 
@@ -41,6 +43,7 @@ def apply_chat_template_and_get_ranges(tokenizer, model_name: str, instruction: 
 if __name__ == "__main__":
 
     cache_dir = "./cache/"
+    hook_dir  = "/dev/shm/vllm_hook" # None # 
     model = 'ibm-granite/granite-3.1-8b-instruct'  # 'Qwen/Qwen2-1.5B-Instruct' # 'mistralai/Mistral-7B-Instruct-v0.3' # 
     
     dtype_map = {
@@ -55,6 +58,7 @@ if __name__ == "__main__":
         analyzer_name="attn_tracker",
         config_file=f'model_configs/attention_tracker/{model.split("/")[-1]}.json',
         download_dir=cache_dir,
+        hook_dir=hook_dir,
         gpu_memory_utilization=0.7,
         max_model_len=2048,
         trust_remote_code=True,

--- a/examples/demo_corer.py
+++ b/examples/demo_corer.py
@@ -7,6 +7,8 @@ from typing import List
 mp.set_start_method("spawn", force=True)
 os.environ["VLLM_USE_V1"] = "1"
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+os.environ.setdefault("VLLM_HOOK_USE_SAFETENSORS", "1")
+os.environ.setdefault("VLLM_HOOK_ASYNC_SAVE", "1")
 
 from vllm_hook_plugins import HookLLM
 
@@ -63,6 +65,7 @@ def apply_chat_template_and_get_ranges(tokenizer, model_name: str, query: str, d
 if __name__ == "__main__":
 
     cache_dir = "./cache/"
+    hook_dir  = "/dev/shm/vllm_hook" # None # 
     model = 'mistralai/Mistral-7B-Instruct-v0.3' # 'ibm-granite/granite-3.1-8b-instruct'  # 'Qwen/Qwen2-1.5B-Instruct' #
     
     dtype_map = {
@@ -77,6 +80,7 @@ if __name__ == "__main__":
         analyzer_name="core_reranker",
         config_file=f'model_configs/core_reranker/{model.split("/")[-1]}.json',
         download_dir=cache_dir,
+        hook_dir=hook_dir,
         gpu_memory_utilization=0.7,
         max_model_len=2048,
         trust_remote_code=True,

--- a/vllm_hook_plugins/vllm_hook_plugins/run_utils.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/run_utils.py
@@ -21,11 +21,23 @@ def latest_run_id(run_id_file: str) -> str:
     return ids[-1]
 
 
-def _artifact_glob(hook_dir: str, run_id: str) -> List[str]:
+def _qk_glob(hook_dir: str, run_id: str, filename: str, timeout: float = 0.0) -> List[str]:
     """Return a list of shared artifact files for a run."""
-    patt_new = os.path.join(hook_dir, run_id, "**", "qk.pt")
-    paths = glob.glob(patt_new, recursive=True)
-    return paths
+    patt = os.path.join(hook_dir, run_id, "**", filename)
+    paths = glob.glob(patt, recursive=True)
+    if paths or timeout <= 0:
+        return paths
+    json_patt = (
+        os.path.join(hook_dir, run_id, "**", "qk.json")
+        if filename == "qk.safetensors" else None
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(0.001)
+        paths = glob.glob(patt, recursive=True)
+        if paths and (json_patt is None or glob.glob(json_patt, recursive=True)):
+            return paths
+    return []
 
 
 def _hs_glob(hook_dir: str, run_id: str, filename: str, timeout: float = 0.0) -> List[str]:
@@ -204,21 +216,111 @@ def load_and_merge_hs_cache(hook_dir: str, run_id: str) -> Dict[str, Any]:
     return merged
 
 
+def _load_and_merge_qk_safetensors(hook_dir: str, run_id: str, st_paths: List[str]) -> Dict[str, Any]:
+    """Load safetensors Q/K artifacts and merge across TP shards."""
+    import json
+    import torch
+    from safetensors import safe_open
+    from torch.nn.utils.rnn import pad_sequence
+
+    shards = []
+    for p in st_paths:
+        meta_path = p.replace("qk.safetensors", "qk.json")
+        with open(meta_path) as f:
+            meta = json.load(f)
+        tp_rank = meta.get("tp_rank", 0)
+        hookq_mode = meta.get("hookq_mode", "all_tokens")
+        batch_size = meta.get("batch_size")
+
+        qk_cache: Dict[str, Any] = {}
+        with safe_open(p, framework="pt", device="cpu") as sf:
+            for item in meta["layer_order"]:
+                t_q = sf.get_tensor(item["key_q"])
+                t_k = sf.get_tensor(item["key_k"])
+                seq_lens = meta.get("seq_lens")
+                if hookq_mode == "all_tokens":
+                    # q and k are padded (bs, max_seq, heads*head_dim) — unpad using seq_lens
+                    if seq_lens is not None:
+                        q_list = [t_q[i, :seq_lens[i], :] for i in range(t_q.shape[0])]
+                        k_list = [t_k[i, :seq_lens[i], :] for i in range(t_k.shape[0])]
+                    else:
+                        q_list = [t_q[i] for i in range(t_q.shape[0])]
+                        k_list = [t_k[i] for i in range(t_k.shape[0])]
+                else:
+                    # last_token: q is (bs, head_dim); k is padded (bs, max_seq, head_dim) — unpad k
+                    q_list = [t_q[i] for i in range(t_q.shape[0])]
+                    if seq_lens is not None:
+                        k_list = [t_k[i, :seq_lens[i], :] for i in range(t_k.shape[0])]
+                    else:
+                        k_list = [t_k[i] for i in range(t_k.shape[0])]
+                qk_cache[item["module_name"]] = {
+                    "q": q_list,
+                    "k_all": k_list,
+                    "layer_num": item["layer_num"],
+                }
+
+        shards.append((tp_rank, {"config": meta["config"], "qk_cache": qk_cache}))
+    shards.sort(key=lambda x: x[0])
+
+    if len(shards) == 1:
+        return shards[0][1]
+
+    base_cfg = shards[0][1]["config"]
+    merged: Dict[str, Any] = {"config": base_cfg, "qk_cache": {}}
+    module_names: set = set()
+    for _, shard in shards:
+        module_names.update(shard["qk_cache"].keys())
+
+    for module_name in module_names:
+        layer_num = None
+        per_shard_q: List[List[Any]] = []
+        per_shard_k: List[List[Any]] = []
+        for _, shard in shards:
+            entry = shard["qk_cache"].get(module_name)
+            if entry is None:
+                continue
+            if layer_num is None:
+                layer_num = entry["layer_num"]
+            per_shard_q.append(entry["q"])
+            per_shard_k.append(entry["k_all"])
+
+        bs = len(per_shard_q[0])
+        merged["qk_cache"][module_name] = {
+            "q": [torch.cat([qs[i] for qs in per_shard_q], dim=-1) for i in range(bs)],
+            "k_all": [torch.cat([ks[i] for ks in per_shard_k], dim=-1) for i in range(bs)],
+            "layer_num": layer_num,
+        }
+
+    return merged
+
+
 def load_and_merge_qk_cache(hook_dir: str, run_id: str):
     """
     Load all shareds for run_id and merge into a single cache.
     Returns a dict with keys: config, qk_cache, meta.
+    Auto-detects safetensors format when VLLM_HOOK_USE_SAFETENSORS=1.
     """
     import torch
 
-    shared_paths = _artifact_glob(hook_dir, run_id)
-    if not shared_paths:
+    async_save = os.environ.get("VLLM_HOOK_ASYNC_SAVE", "0") == "1"
+    poll_timeout = 5.0 if async_save else 0.0
+
+    if os.environ.get("VLLM_HOOK_USE_SAFETENSORS", "0") == "1":
+        st_paths = _qk_glob(hook_dir, run_id, "qk.safetensors", timeout=poll_timeout)
+        if not st_paths:
+            raise FileNotFoundError(
+               f"No safetensors artifacts found for run_id={run_id} under {hook_dir}"
+            )
+        return _load_and_merge_qk_safetensors(hook_dir, run_id, st_paths)
+
+    paths = _qk_glob(hook_dir, run_id, "qk.pt", timeout=poll_timeout)
+    if not paths:
         raise FileNotFoundError(
             f"No Q/K cache artifacts found for run_id={run_id} under {hook_dir}"
         )
 
     shareds = []
-    for p in shared_paths:
+    for p in paths:
         cache = torch.load(p, map_location="cpu")
         meta = cache.get("meta", {})
         tp_rank = int(meta.get("tp_rank", 0))

--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py
@@ -1,10 +1,12 @@
 import os
 import math
+import queue
+import re
+import threading
 import torch
 from typing import Dict, List
 from vllm.v1.worker.gpu_worker import Worker as V1Worker
 from vllm.forward_context import get_forward_context
-import re
 from vllm.distributed import parallel_state as ps
 
 ATTN_PATTERNS = [
@@ -48,23 +50,40 @@ class ProbeHookQKWorker(V1Worker):
         self.hook_dir = os.environ.get("VLLM_HOOK_DIR")
         self.run_id_file = os.environ.get("VLLM_RUN_ID")
         self.hookq_mode = os.environ.get("VLLM_HOOKQ_MODE", "all_tokens") # ["last_token", "all_tokens"]
-        tp_rank = int(ps.get_tensor_model_parallel_rank())
-        
+
         if not all([self.hook_dir, self.hook_flag, self.run_id_file]):
             print("Missing hook environment variables")
             return            
 
         self.layer_to_heads = self._parse_layer_heads()
         self.important_layers = set(self.layer_to_heads.keys())
-        
+
         self._run_cache = {}
-        
+
+        # Background I/O thread (only when VLLM_HOOK_ASYNC_SAVE=1).
+        if os.environ.get("VLLM_HOOK_ASYNC_SAVE", "0") == "1":
+            if not getattr(self, '_io_thread_started', False):
+                self._save_queue: queue.Queue = queue.Queue(maxsize=4)
+                self._io_thread = threading.Thread(
+                    target=self._background_save_loop,
+                    daemon=True,
+                    name="vllm-hook-qk-io",
+                )
+                self._io_thread.start()
+                self._io_thread_started = True
+
+        # Per-pass state written by execute_model(), read by the hook.
+        # Avoids all filesystem I/O inside the hook closure.
+        self._hook_active = False
+        self._current_run_id = None
+
         cfg = model.config
-        num_h = int(getattr(cfg, "num_attention_heads"))
-        num_kv = int(getattr(cfg, "num_key_value_heads", num_h))
-        hidden = int(getattr(cfg, "hidden_size"))
+        text_cfg = getattr(cfg, "text_config", cfg)
+        num_h = int(getattr(text_cfg, "num_attention_heads"))
+        num_kv = int(getattr(text_cfg, "num_key_value_heads", num_h))
+        hidden = int(getattr(text_cfg, "hidden_size"))
         head_dim = hidden // num_h
-        attn_mult = float(getattr(cfg, "attention_multiplier", 1 / math.sqrt(head_dim)))
+        attn_mult = float(getattr(text_cfg, "attention_multiplier", 1 / math.sqrt(head_dim)))
         self._conf = dict(
             num_attention_heads=num_h,
             num_key_value_heads=num_kv,
@@ -74,15 +93,11 @@ class ProbeHookQKWorker(V1Worker):
         )
 
         def qkv_hook(input, module_name):
-
-            if not os.path.exists(self.hook_flag): # hooks deactivated
+            # Fast-path: checked once per execute_model() call, not per hook.
+            if not self._hook_active:
                 return None
 
-            elif os.path.exists(self.run_id_file): # hooks activated
-                run_id = (open(self.run_id_file).read().strip().split('\n'))[-1]
-
-            else:
-                raise Exception("run_id not found.")
+            run_id = self._current_run_id
 
             ctx = get_forward_context()
             metadata = getattr(ctx, "attn_metadata", None)
@@ -90,16 +105,26 @@ class ProbeHookQKWorker(V1Worker):
             # Warmup or non-attention passes: nothing to do
             if metadata is None:
                 return
-        
-            # seq_lens = metadata.seq_lens
-            seq_lens = getattr(metadata, "seq_lens", None)
-            if seq_lens is None and module_name in metadata:
-                seq_lens = metadata[module_name].seq_lens
-            
-            # assert (seq_lens).sum() == metadata.num_actual_tokens, "Please set enable_prefix_caching=False for batch processing."
-            last_indices = torch.cumsum(seq_lens, dim=0)
-            bs = len(last_indices)
-            last_indices = torch.cat([torch.tensor([0]).to(last_indices.device), last_indices])
+            if torch.cuda.is_current_stream_capturing():
+                return None
+
+            # The HS worker hooks on "model.layers.<i>", so we look up the corresponding attention key.
+            # query_start_loc is the cumulative sum of per-request *query* token counts (shape [bs+1]).  
+            # Unlike cumsum(seq_lens), it excludes prefix-cached tokens and is always within hidden.shape[0].
+            # For hybrid models (e.g. Qwen3.5), linear_attention layers have no entry in the metadata dict under their own key, 
+            # so we grab query_start_loc from any available entry rather than only the current layer's key.
+            query_start_loc = getattr(metadata, "query_start_loc", None)
+            if query_start_loc is None and isinstance(metadata, dict):
+                for entry in metadata.values():
+                    query_start_loc = getattr(entry, "query_start_loc", None)
+                    if query_start_loc is not None:
+                        break
+
+            if query_start_loc is None:
+                return
+
+            bs = len(query_start_loc) - 1
+            last_indices = query_start_loc
 
             cache = self._run_cache.get(run_id)
             if cache is None:
@@ -113,24 +138,31 @@ class ProbeHookQKWorker(V1Worker):
                 k_all_tokens = cache["qk_cache"][module_name]['k_all']
 
             layer_num = match_attn(module_name)
+            # Accumulate GPU tensors — clone() copies the data immediately so
+            # we own the buffer and don't need a synchronize() before post-pass.
+            # No .cpu() here; transfer happens once in execute_model().
             if self.hookq_mode == "all_tokens":
-                q_tokens.extend([input[0][last_indices[i]:last_indices[i+1],:].detach().cpu() for i in range(bs)])
+                q_tokens.extend([
+                    input[0][last_indices[i]:last_indices[i+1], :].detach().clone()
+                    for i in range(bs)
+                ])
             elif self.hookq_mode == "last_token":
-                q_tokens.extend(list(input[0][last_indices[1:] - 1,:].detach().cpu()))
+                q_tokens.extend([
+                    input[0][last_indices[i+1] - 1, :].detach().clone()
+                    for i in range(bs)
+                ])
             else:
                 raise NotImplementedError
-            k_all_tokens.extend([input[1][last_indices[i]:last_indices[i+1],:].detach().cpu() for i in range(bs)])     
+            k_all_tokens.extend([
+                input[1][last_indices[i]:last_indices[i+1], :].detach().clone()
+                for i in range(bs)
+            ])
 
             cache["qk_cache"][module_name] = {
                 'q': q_tokens,
                 'k_all': k_all_tokens,
                 'layer_num': layer_num
             }
-
-            run_dir = os.path.join(self.hook_dir, run_id, f"tp_rank_{tp_rank}")
-            os.makedirs(run_dir, exist_ok=True)
-            cache_path = os.path.join(run_dir, "qk.pt")
-            torch.save(cache, cache_path)
 
         # register hooks on attention modules 
         self._hooks = []
@@ -142,7 +174,7 @@ class ProbeHookQKWorker(V1Worker):
             if layer_num not in self.important_layers:
                 continue
             hook = module.register_forward_hook(
-                lambda m, i, o, n=name: qkv_hook(i, n)
+                lambda _m, i, _o, n=name: qkv_hook(i, n)
             )
             self._hooks.append(hook)
             matched.append(name)
@@ -166,5 +198,170 @@ class ProbeHookQKWorker(V1Worker):
         
         return result
 
+    def _save_safetensors(self, cpu_cache: dict, run_dir: str):
+        import json as _json
+        from torch.nn.utils.rnn import pad_sequence
+        from safetensors.torch import save_file as _st_save
+
+        out_path = os.path.join(run_dir, "qk.safetensors")
+        tmp_path = out_path + ".tmp"
+        meta_path = os.path.join(run_dir, "qk.json")
+
+        flat_dict: dict = {}
+        layer_order: list = []
+        batch_size = 0
+        seq_lens: list = []
+
+        for mod_name, entry in cpu_cache["qk_cache"].items():
+            safe_key_q = mod_name.replace(".", "__") + "__q"
+            safe_key_k = mod_name.replace(".", "__") + "__k"
+
+            if self.hookq_mode == "all_tokens":
+                flat_dict[safe_key_q] = pad_sequence(entry['q'], batch_first=True)
+                flat_dict[safe_key_k] = pad_sequence(entry['k_all'], batch_first=True)
+                if not seq_lens:
+                    seq_lens = [t.shape[0] for t in entry['q']]
+            else:
+                # last_token: q is 1D (head_dim,) per request; k_all is 2D (seq_len, head_dim)
+                # with variable seq_len across the batch — pad k, stack q.
+                flat_dict[safe_key_q] = torch.stack(entry['q'])
+                flat_dict[safe_key_k] = pad_sequence(entry['k_all'], batch_first=True)
+                if not seq_lens:
+                    seq_lens = [t.shape[0] for t in entry['k_all']]
+
+            batch_size = flat_dict[safe_key_q].shape[0]
+            layer_order.append({
+                "key_q": safe_key_q,
+                "key_k": safe_key_k,
+                "module_name": mod_name,
+                "layer_num": entry["layer_num"],
+            })
+
+        _st_save(flat_dict, tmp_path)
+        os.rename(tmp_path, out_path)
+
+        meta = {
+            "config": cpu_cache["config"],
+            "layer_order": layer_order,
+            "batch_size": batch_size,
+            "hookq_mode": self.hookq_mode,
+            "tp_rank": int(ps.get_tensor_model_parallel_rank()),
+        }
+        if seq_lens:
+            meta["seq_lens"] = seq_lens
+        meta_tmp = meta_path + ".tmp"
+        with open(meta_tmp, "w") as f:
+            _json.dump(meta, f)
+        os.rename(meta_tmp, meta_path)
+
+    def _background_save_loop(self):
+        """Drain the save queue and write artifacts to disk.
+
+        Activated when VLLM_HOOK_ASYNC_SAVE=1. Runs as a daemon thread in the
+        worker subprocess. Each item is (run_id, cpu_cache, run_dir).
+        """
+        while True:
+            run_id, cpu_cache, run_dir = self._save_queue.get()
+            try:
+                os.makedirs(run_dir, exist_ok=True)
+                if os.environ.get("VLLM_HOOK_USE_SAFETENSORS", "0") == "1":
+                    self._save_safetensors(cpu_cache, run_dir)
+                else:
+                    out_path = os.path.join(run_dir, "qk.pt")
+                    tmp_path = out_path + ".tmp"
+                    with open(tmp_path, "wb") as f:
+                        torch.save(cpu_cache, f)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.rename(tmp_path, out_path)
+            except Exception as e:
+                print(f"background save failed for {run_id}: {e}")
+            finally:
+                self._save_queue.task_done()
+
     def execute_model(self, *args, **kwargs):
-        return super().execute_model(*args, **kwargs)
+        hooks_configured = all([
+            getattr(self, "hook_dir", None),
+            getattr(self, "hook_flag", None),
+            getattr(self, "run_id_file", None),
+        ])
+
+        if hooks_configured and os.path.exists(self.hook_flag):
+            if os.path.exists(self.run_id_file):
+                run_id = open(self.run_id_file).read().strip().split("\n")[-1]
+            else:
+                run_id = None
+            self._hook_active = run_id is not None
+            self._current_run_id = run_id
+        else:
+            self._hook_active = False
+            self._current_run_id = None
+
+        result = super().execute_model(*args, **kwargs)
+
+        if self._hook_active:
+            # Read req_ids after the forward pass — input_batch is populated
+            # by super().execute_model() from the scheduler_output.
+            try:
+                num_reqs = self.model_runner.input_batch.num_reqs
+                _req_ids_raw = self.model_runner.input_batch.req_ids
+                self._current_req_ids = list(_req_ids_raw[:num_reqs])
+            except Exception:
+                self._current_req_ids = None
+
+        # --- Post-pass: GPU→CPU transfer and save (once per pass, not per layer) ---
+        run_id = self._current_run_id
+        if self._hook_active and run_id is not None:
+            cache = self._run_cache.get(run_id)
+            has_data = cache is not None and any(
+                entry['q'] for entry in cache.get("qk_cache", {}).values()
+            )
+            req_ids = getattr(self, "_current_req_ids", None)
+            call_bs = len(req_ids) if req_ids is not None else None
+
+            if has_data and call_bs != 0:
+                tp_rank = int(ps.get_tensor_model_parallel_rank())
+                run_dir = os.path.join(self.hook_dir, run_id, f"tp_rank_{tp_rank}")
+                os.makedirs(run_dir, exist_ok=True)
+
+                if call_bs is not None:
+                    perm = sorted(range(call_bs), key=lambda idx: req_ids[idx])
+                else:
+                    perm = None
+
+                def _to_cpu_sorted(tensors):
+                    if call_bs is None or perm is None:
+                        return [t.cpu() for t in tensors]
+                    prefix = [t.cpu() for t in tensors[:-call_bs]]
+                    tail = tensors[-call_bs:]
+                    return prefix + [tail[i].cpu() for i in perm]
+
+                cpu_cache = {
+                    "config": cache["config"],
+                    "qk_cache": {
+                        mod: {
+                            "q": _to_cpu_sorted(entry["q"]),
+                            "k_all": _to_cpu_sorted(entry["k_all"]),
+                            "layer_num": entry["layer_num"],
+                        }
+                        for mod, entry in cache["qk_cache"].items()
+                    },
+                }
+
+                for stale_id in [k for k in self._run_cache if k != run_id]:
+                    del self._run_cache[stale_id]
+
+                if os.environ.get("VLLM_HOOK_ASYNC_SAVE", "0") == "1":
+                    self._save_queue.put((run_id, cpu_cache, run_dir))
+                elif os.environ.get("VLLM_HOOK_USE_SAFETENSORS", "0") == "1":
+                    self._save_safetensors(cpu_cache, run_dir)
+                else:
+                    out_path = os.path.join(run_dir, "qk.pt")
+                    tmp_path = out_path + ".tmp"
+                    with open(tmp_path, "wb") as f:
+                        torch.save(cpu_cache, f)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.rename(tmp_path, out_path)
+
+        return result


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR does and why -->
refactor ProbeHookQKWorker to match ProbeHiddenStatesWorker patterns, including 
1. defer CPU transfer and artifact save to a single post-pass in execute_model(); 
3. Add VLLM_HOOK_ASYNC_SAVE and VLLM_HOOK_USE_SAFETENSORS support with matching loader logic in run_utils (_qk_glob, _load_and_merge_qk_safetensors)

## Type of contribution
- [ ] New worker
- [ ] New analyzer
- [ ] Bug fix
- [x] Other (describe below)
performance improvement

## Files modified
<!-- List the files changed. Note: hook_llm.py should not be modified. -->
examples/demo_attntracker.py
examples/demo_corer.py
vllm_hook_plugins/vllm_hook_plugins/run_utils.py
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py
- [x] I have NOT modified `hook_llm.py`

## Plugin architecture checklist
- [ ] New workers/analyzers are registered via `PluginRegistry` in `__init__.py`
- [ ] New workers extend `V1Worker` (not `HookLLM`)
- [ ] `hooks_on=(prefill, generate)` flag is set correctly for any new worker registration
- [ ] Examples or notebooks are included for new features

## Testing
<!-- Describe how you tested this. Which demo/example did you run? -->
```
python examples/demo_attntracker.py 
python examples/demo_corer.py 
```

## Related issue
<!-- Link any related issue: Closes #123 -->
NA