### PR TITLE
steer_activation_worker: implement last-token-per-sequence mode for add_vector

### DIFF
--- a/vllm_hook_plugins/vllm_hook_plugins/workers/steer_activation_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/steer_activation_worker.py
@@ -3,6 +3,36 @@ import json
 import torch
 from typing import Dict, Optional
 from vllm.v1.worker.gpu_worker import Worker as V1Worker
+from vllm.forward_context import get_forward_context
+
+
+def _last_token_indices(residuals: torch.Tensor) -> Optional[torch.Tensor]:
+    """Return per-sequence last-query-token indices into the flat residuals.
+
+    Returns None when no real forward is in flight (warmup, CUDA graph
+    capture, or absent attn_metadata) so the caller can no-op.
+
+    Hybrid-model note: in models like Qwen3.5, linear-attention layers may
+    have no entry under their own key, so query_start_loc is taken from any
+    available metadata entry (the query layout is shared across layers).
+    """
+    if torch.cuda.is_current_stream_capturing():
+        return None
+    ctx = get_forward_context()
+    metadata = getattr(ctx, "attn_metadata", None)
+    if metadata is None:
+        return None
+
+    query_start_loc = getattr(metadata, "query_start_loc", None)
+    if query_start_loc is None and isinstance(metadata, dict):
+        for entry in metadata.values():
+            query_start_loc = getattr(entry, "query_start_loc", None)
+            if query_start_loc is not None:
+                break
+    if query_start_loc is None:
+        return None
+
+    return query_start_loc[1:] - 1
 
 
 class SteerHookActWorker(V1Worker):
@@ -56,9 +86,23 @@ class SteerHookActWorker(V1Worker):
             if self.steering_method == "add_vector":
                 if self.apply_at_all_positions:
                     steering_vec = steering_vec.view(1, -1)
+                    residuals = residuals + self.coefficient * steering_vec
                 else:
-                    raise NotImplementedError("Only supports apply_at_all_positions=True for now.")
-                residuals = residuals + self.coefficient * steering_vec
+                    # Last-token-per-sequence steering. Mirrors the `last_token`
+                    # idiom used by probe_hidden_states_worker: in vLLM v1 the
+                    # decoder-block output is flattened to [total_tokens, hidden]
+                    # and query_start_loc[i+1]-1 is the last query-token index
+                    # of sequence i (works uniformly for prefill, decode, and
+                    # mixed batches; matches HF-hook "score at final position"
+                    # semantics used by many steering-vector papers).
+                    last_indices = _last_token_indices(residuals)
+                    if last_indices is None:
+                        # Warmup / CUDA graph capture / non-attention pass.
+                        return output
+                    residuals = residuals.clone()
+                    residuals[last_indices] = (
+                        residuals[last_indices] + self.coefficient * steering_vec
+                    )
                 
             elif self.steering_method == "adjust_rs":
                 unit_vec = self.unit_vector.to(residuals.device, dtype=residuals.dtype)


### PR DESCRIPTION
## Summary

Replaces the `NotImplementedError` raised when `apply_at_all_positions=False` in `SteerHookActWorker` with a working last-token-per-sequence injection path, so the steering worker matches the `last_token` / `all_tokens` symmetry already offered by `probe_hidden_states_worker` and `probe_hookqk_worker`.

Default behaviour is unchanged — `apply_at_all_positions` still defaults to `True`, and the all-positions path is byte-identical to before.

## Motivation

The extraction-side workers expose both modes:

| Worker | `last_token` mode |
|---|---|
| `probe_hidden_states_worker` | ✅ |
| `probe_hookqk_worker` | ✅ |
| `steer_activation_worker` (before this PR) | ❌ raises `NotImplementedError` |

Many activation-steering workflows (RepE, CAA, contrastive activation, behavioural probes) train and read the steering vector at the **final prompt position only** — see e.g. *Representation Engineering* (Zou et al., 2023), *Steering Llama 2 via Contrastive Activation Addition* (Rimsky et al., 2024). Forcing all-positions injection on those vectors over-steers the prompt context and is known to shift PPL / collapse onset relative to the original method's published semantics. This PR lets users keep the mode they trained with.

## Implementation

A small helper `_last_token_indices(residuals)` extracts per-sequence last-query-token indices from `get_forward_context().attn_metadata.query_start_loc` — the same idiom `probe_hidden_states_worker` already uses for `last_token` extraction (lines 109-125 of that file). The helper returns `None` on warmup / CUDA-graph capture / absent metadata so the hook no-ops safely.

Hybrid-model note: for models like Qwen3.5 where linear-attention layers may lack their own `attn_metadata` entry, the helper falls back to any available entry's `query_start_loc` (the query layout is shared across layers) — same fallback `probe_hidden_states_worker` uses.

The scattered write uses `residuals.clone()` to avoid mutating a tensor vLLM may still hold a reference to.

Scope kept minimal: `adjust_rs` is untouched (its current per-token projection already inherently depends on each position, so an `apply_at_all_positions=False` semantics there needs a separate design decision — happy to follow up if maintainers want it covered too).

## Diff

```diff
- raise NotImplementedError("Only supports apply_at_all_positions=True for now.")
+ last_indices = _last_token_indices(residuals)
+ if last_indices is None:
+     return output
+ residuals = residuals.clone()
+ residuals[last_indices] = (
+     residuals[last_indices] + self.coefficient * steering_vec
+ )
```

Total: +46 / -2 in one file.

## ⚠️ Testing status

**Not tested against a live vLLM runtime** — I do not currently have a GPU box with vLLM installed. Verified:
- ✅ Python AST parse
- ✅ Default-path semantics unchanged (`apply_at_all_positions=True` branch is identical)
- ✅ Idiom mirrors `probe_hidden_states_worker._install_hooks.hs_hook` last-token logic

Marking this PR as **draft** specifically because of (1) — would appreciate maintainer review on:

1. **End-to-end smoke**: run `examples/demo_actsteer.py` (or any add_vector config) with `"apply_at_all_positions": false` set in the config JSON; verify generation completes and the steered output is plausibly different from baseline.
2. **Clone-vs-in-place choice**: I used `residuals.clone()` to be safe; if vLLM v1 guarantees the residual tensor at this hook point is not referenced elsewhere (e.g. for KV cache writes), an in-place `index_add_` would be cheaper. Happy to switch if you confirm.
3. **`adjust_rs` scope**: is leaving `adjust_rs` untouched the right call, or do you want a uniform position-mask design across both methods in this PR?

## Test plan

- [ ] Maintainer runs `examples/demo_actsteer.py` with `"apply_at_all_positions": false` and confirms no exception
- [ ] Generated output differs from baseline (steering is taking effect)
- [ ] Output with `apply_at_all_positions=true` is unchanged versus pre-PR (regression check)
