### PR TITLE
Fix README commands and add HookLLM cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Each use case (e.g. attention tracker, activation steering, hidden states extrac
 
 ```bash
 git clone https://github.com/IBM/vLLM-Hook.git
-cd vLLm.hook
+cd vLLM-Hook
 ```
 
 ### 2. (Optional) Create an environment 
 
 ```bash
-conda create -n vllm_hook_env
+conda create -n vllm_hook_env python=3.12 pip
 conda activate vllm_hook_env
 ```
 
@@ -102,7 +102,7 @@ python examples/demo_attntracker.py
 Notebook 📓: `notebooks/demo_corer.ipynb` <br />
 CLI 🧰 : 
 ```bash
-python examples/demo_actsteer.py
+python examples/demo_corer.py
 ```
 
 ### 3. Activation Steering (Enhanced instruction following via activation steering)
@@ -110,7 +110,7 @@ python examples/demo_actsteer.py
 Notebook 📓: `notebooks/demo_actsteer.ipynb` <br />
 CLI 🧰 : 
 ```bash
-python examples/demo_corer.py
+python examples/demo_actsteer.py
 ```
 
 You can customize model configurations in the `model_configs/` folder, e.g.:

--- a/vllm_hook_plugins/vllm_hook_plugins/hook_llm.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/hook_llm.py
@@ -230,5 +230,13 @@ class HookLLM:
         return dispatch_disk_analyze(self.analyzer, analyzer_spec,
                                      run_id=effective_run_id, run_ids=run_ids)
 
-    def __del__(self):
+    def close(self):
+        """Release resources owned by this wrapper."""
         teardown_shm(getattr(self, "_hook_shm", None))
+        self._hook_shm = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- Fix README setup instructions and demo command references
- Add explicit `HookLLM.close()` cleanup for shared memory resources
- Make `HookLLM.__del__` call `close()` defensively
