### PR TITLE
Fix/probe workers chunked prefill

### DIFF
--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
@@ -107,9 +107,18 @@ class ProbeHiddenStatesWorker:
         self._batch_cache_key = None
         self._batch_cache_entries = None  # list[dict] of resolved per-request info
 
-        def _resolve_batch(req_ids, bs):
+        def _resolve_batch(req_ids, bs, query_start_loc):
             """Build the per-batch list of capturing requests. Called once per
             forward step (on the first hook fire that gets here)."""
+            try:
+                input_batch = self.model_runner.input_batch
+                num_computed = input_batch.num_computed_tokens_cpu
+                num_prompt   = input_batch.num_prompt_tokens
+            except Exception:
+                # fall back to the old behavior and capture every chunk if these attributes aren't available on the running vLLM version
+                num_computed = None
+                num_prompt = None
+
             entries = []
             for i in range(bs):
                 req_id = req_ids[i]
@@ -124,17 +133,27 @@ class ProbeHiddenStatesWorker:
                 # hooks_on != "both"; output_token_ids state is stable for
                 # the duration of one forward step.
                 hooks_on = extra.get("hooks_on", self._default_hooks_on)
+                is_prefill = len(req_state.output_token_ids) == 0
                 if hooks_on != "both":
-                    is_prefill = len(req_state.output_token_ids) == 0
                     if hooks_on == "prefill" and not is_prefill:
                         continue
                     if hooks_on == "decode" and is_prefill:
                         continue
+
+                # With chunked-prefill, in last_token mode, only capture on the final chunk of the prefill
+                # i.e., when computed-after-step reaches num_prompt_tokens
+                req_mode = extra.get("hs_mode", self.hs_mode)
+                if (is_prefill and req_mode == "last_token" and num_computed is not None and num_prompt is not None):
+                    chunk_len = int(query_start_loc[i + 1].item() - query_start_loc[i].item())
+                    if int(num_computed[i]) + chunk_len < int(num_prompt[i]):
+                        # Mid-prefill chunk doesn't need capture
+                        continue
+
                 entries.append({
                     "i": i,
                     "req_id": req_id,
                     "output_layers": output_layers,  # list or None ("all layers")
-                    "hs_mode": extra.get("hs_mode", self.hs_mode),
+                    "hs_mode": req_mode,
                     "save_to_disk": bool(extra.get("save_to_disk")),
                 })
             return entries
@@ -167,7 +186,7 @@ class ProbeHiddenStatesWorker:
                     return
                 bs = len(query_start_loc) - 1
                 self._batch_cache_key = cache_key
-                self._batch_cache_entries = _resolve_batch(req_ids, bs)
+                self._batch_cache_entries = _resolve_batch(req_ids, bs, query_start_loc)
                 self._batch_cache_qsl = query_start_loc
 
             entries = self._batch_cache_entries

--- a/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py
+++ b/vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py
@@ -161,6 +161,14 @@ class ProbeHookQKWorker:
             except Exception:
                 return
 
+            try:
+                num_computed = self.model_runner.input_batch.num_computed_tokens_cpu
+                num_prompt   = self.model_runner.input_batch.num_prompt_tokens
+            except Exception:
+                # fall back to the old behavior and capture every chunk if these attributes aren't available on the running vLLM version
+                num_computed = None
+                num_prompt = None
+
             for i in range(bs):
                 req_id = req_ids[i]
                 req_state = self.model_runner.requests.get(req_id)
@@ -190,8 +198,8 @@ class ProbeHookQKWorker:
                 # to detect the first (prefill) pass. This is robust to prefix
                 # caching where query_len < seq_len even on the first pass.
                 hooks_on = extra.get("hooks_on", self._default_hooks_on)
+                is_prefill = len(req_state.output_token_ids) == 0
                 if hooks_on != "both":
-                    is_prefill = len(req_state.output_token_ids) == 0
                     if hooks_on == "prefill" and not is_prefill:
                         continue
                     if hooks_on == "decode" and is_prefill:
@@ -202,6 +210,14 @@ class ProbeHookQKWorker:
 
                 start = int(last_indices[i].item())
                 end = int(last_indices[i + 1].item())
+
+                # With chunked-prefill, in last_token mode, only capture on the final chunk of the prefill
+                # i.e., when computed-after-step reaches num_prompt_tokens
+                if (is_prefill and req_mode == "last_token" and num_computed is not None and num_prompt is not None):
+                    chunk_len = end - start
+                    if int(num_computed[i]) + chunk_len < int(num_prompt[i]):
+                        # Mid-prefill chunk doesn't need capture
+                        continue
 
                 # Accumulate GPU tensors — clone() copies data immediately so we
                 # own the buffer; .cpu() is deferred to retrieval/flush.


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR does and why -->
vLLM's chunked prefill splits long prompts across multiple forward passes. Both `ProbeHiddenStatesWorker` and `ProbeHookQKWorker` previously hooked on every chunk's forward pass and appended one entry per chunk to the per-request capture list in `last_token` mode.

## Type of contribution
- [ ] New worker
- [ ] New analyzer
- [x] Bug fix
- [ ] Other (describe below)

## Files modified
<!-- List the files changed. -->
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hidden_states_worker.py
vllm_hook_plugins/vllm_hook_plugins/workers/probe_hookqk_worker.py

The following files are **core infrastructure**. Please discuss with maintainers before modifying:
`hook_llm.py`, `_hook_plugin.py`, `registry.py`, `hook_client.py`, `run_utils.py`, `shm_utils.py`, `workers/_common.py`

- [x] I have NOT modified core files, OR I have discussed the change with maintainers
- [ ] If I added a new worker/analyzer, I registered it in `__init__.py`

## Plugin architecture checklist
- [ ] New workers/analyzers are registered via `PluginRegistry` in `__init__.py`
- [ ] New workers are implemented as `worker_extension_cls`  (for in-band artifact retrieval and concurrent request support)
- [ ] Examples or notebooks are included for new features

## Testing
<!-- Describe how you tested this. Which demo/example did you run? -->
Tested on internal test files before and after the fixes. Before the fixes, the captured artifacts have a dimension for the number of chunks in `last_token` mode. After the fixes, those artifacts are correctly sized for only the last token only.

## Related issue
<!-- Link any related issue: Closes #123 -->
Closes #22 